### PR TITLE
Updated to latest Aphiria build, made name changes to App\App (now App\GlobalModule)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- Renamed `App\App` to `App\GlobalModule` ([#21](https://github.com/aphiria/app/pull/21))
+- Renamed all `IModule::build()` methods to `configure()` ([#21](https://github.com/aphiria/app/pull/21))
 - Updated Composer scripts to not run `php aphiria framework:flushcaches` anymore after `composer install` and `composer update` ([#18](https://github.com/aphiria/app/pull/18))
 
 ## [v1.0.0-alpha2](https://github.com/aphiria/app/compare/v1.0.0-alpha1...v1.0.0-alpha2) (2021-2-15)

--- a/aphiria
+++ b/aphiria
@@ -7,7 +7,7 @@ use Aphiria\DependencyInjection\Container;
 use Aphiria\DependencyInjection\IContainer;
 use Aphiria\DependencyInjection\IServiceResolver;
 use Aphiria\Framework\Console\Builders\ConsoleApplicationBuilder;
-use App\App;
+use App\GlobalModule;
 
 require __DIR__ . '/vendor/autoload.php';
 
@@ -18,7 +18,9 @@ $container->bindInstance([IServiceResolver::class, IContainer::class, Container:
 
 // Build and run our application
 global $argv;
-$statusCode = (new ConsoleApplicationBuilder($container))->withModule(new App($container))
+$globalModule = new GlobalModule($container);
+$globalModule->bootstrap();
+$statusCode = (new ConsoleApplicationBuilder($container))->withModule($globalModule)
     ->build()
     ->handle($argv);
 exit($statusCode);

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         }
     },
     "require": {
-        "aphiria/aphiria": "1.*@dev",
+        "aphiria/aphiria": "1.x-dev",
         "ext-mbstring": "*",
         "php": ">=8.0",
         "symfony/dotenv": "~5.2"

--- a/public/index.php
+++ b/public/index.php
@@ -8,7 +8,7 @@ use Aphiria\DependencyInjection\IServiceResolver;
 use Aphiria\Framework\Api\Builders\ApiApplicationBuilder;
 use Aphiria\Net\Http\IRequest;
 use Aphiria\Net\Http\StreamResponseWriter;
-use App\App;
+use App\GlobalModule;
 
 require __DIR__ . '/../vendor/autoload.php';
 
@@ -18,7 +18,9 @@ Container::$globalInstance = $container;
 $container->bindInstance([IServiceResolver::class, IContainer::class, Container::class], $container);
 
 // Build and run our application
-$response = (new ApiApplicationBuilder($container))->withModule(new App($container))
+$globalModule = new GlobalModule($container);
+$globalModule->bootstrap();
+$response = (new ApiApplicationBuilder($container))->withModule($globalModule)
     ->build()
     ->handle($container->resolve(IRequest::class));
 (new StreamResponseWriter())->writeResponse($response);

--- a/src/Demo/Api/Controllers/UserController.php
+++ b/src/Demo/Api/Controllers/UserController.php
@@ -76,7 +76,6 @@ final class UserController extends Controller
      *
      * @return IResponse The response containing all users
      * @throws HttpException Thrown if there was an error creating the response
-     * @psalm-suppress ArgumentTypeCoercion https://github.com/vimeo/psalm/issues/4871
      */
     #[Get(''), Middleware(DummyAuthorization::class)]
     public function getAllUsers(): IResponse

--- a/src/Demo/DemoModule.php
+++ b/src/Demo/DemoModule.php
@@ -20,7 +20,7 @@ final class DemoModule implements IModule
     /**
      * @inheritdoc
      */
-    public function build(IApplicationBuilder $appBuilder): void
+    public function configure(IApplicationBuilder $appBuilder): void
     {
         $this->withBinders($appBuilder, new UserServiceBinder())
             ->withProblemDetails(

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -20,7 +20,10 @@ class IntegrationTestCase extends BaseIntegrationTestCase
      */
     protected function createApplication(IContainer $container): IRequestHandler
     {
-        return (new ApiApplicationBuilder($container))->withModule(new GlobalModule($container))
+        $globalModule = new GlobalModule($container);
+        $globalModule->bootstrap();
+
+        return (new ApiApplicationBuilder($container))->withModule($globalModule)
             ->build();
     }
 }

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -8,7 +8,7 @@ use Aphiria\DependencyInjection\IContainer;
 use Aphiria\Framework\Api\Builders\ApiApplicationBuilder;
 use Aphiria\Framework\Api\Testing\PhpUnit\IntegrationTestCase as BaseIntegrationTestCase;
 use Aphiria\Net\Http\IRequestHandler;
-use App\App;
+use App\GlobalModule;
 
 /**
  * Defines the base integration test case
@@ -20,7 +20,7 @@ class IntegrationTestCase extends BaseIntegrationTestCase
      */
     protected function createApplication(IContainer $container): IRequestHandler
     {
-        return (new ApiApplicationBuilder($container))->withModule(new App($container))
+        return (new ApiApplicationBuilder($container))->withModule(new GlobalModule($container))
             ->build();
     }
 }


### PR DESCRIPTION
Updated to latest build of Aphiria, renamed build() to configure() for modules, renamed App\App to App\GlobalModule to more accurately reflect what it is, also made GlobalModule a bootstrapper itself